### PR TITLE
Replace EJB with equivalent CDI funcionality. Fixes #151

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .metadata
 /.classpath
 /.project
+nb-configuration.xml

--- a/src/main/java/org/eclipse/cargotracker/application/internal/DefaultBookingService.java
+++ b/src/main/java/org/eclipse/cargotracker/application/internal/DefaultBookingService.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.ejb.Stateless;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 
 import org.eclipse.cargotracker.application.BookingService;
@@ -19,9 +19,11 @@ import org.eclipse.cargotracker.domain.model.location.Location;
 import org.eclipse.cargotracker.domain.model.location.LocationRepository;
 import org.eclipse.cargotracker.domain.model.location.UnLocode;
 import org.eclipse.cargotracker.domain.service.RoutingService;
+import org.eclipse.cargotracker.infrastructure.CargoTransactional;
 
 // TODO [Jakarta EE 8] Adopt the Date-Time API.
-@Stateless
+@RequestScoped
+@CargoTransactional
 public class DefaultBookingService implements BookingService {
 
 	@Inject

--- a/src/main/java/org/eclipse/cargotracker/application/internal/DefaultCargoInspectionService.java
+++ b/src/main/java/org/eclipse/cargotracker/application/internal/DefaultCargoInspectionService.java
@@ -2,11 +2,9 @@ package org.eclipse.cargotracker.application.internal;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.ejb.Stateless;
+import javax.enterprise.context.RequestScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
-
 import org.eclipse.cargotracker.application.ApplicationEvents;
 import org.eclipse.cargotracker.application.CargoInspectionService;
 import org.eclipse.cargotracker.domain.model.cargo.Cargo;
@@ -14,10 +12,12 @@ import org.eclipse.cargotracker.domain.model.cargo.CargoRepository;
 import org.eclipse.cargotracker.domain.model.cargo.TrackingId;
 import org.eclipse.cargotracker.domain.model.handling.HandlingEventRepository;
 import org.eclipse.cargotracker.domain.model.handling.HandlingHistory;
+import org.eclipse.cargotracker.infrastructure.CargoTransactional;
 import org.eclipse.cargotracker.infrastructure.events.cdi.CargoInspected;
 
 //TODO [Jakarta EE 8] Adopt the Date-Time API.
-@Stateless
+@RequestScoped
+@CargoTransactional
 public class DefaultCargoInspectionService implements CargoInspectionService {
 
 	@Inject

--- a/src/main/java/org/eclipse/cargotracker/application/internal/DefaultHandlingEventService.java
+++ b/src/main/java/org/eclipse/cargotracker/application/internal/DefaultHandlingEventService.java
@@ -3,7 +3,7 @@ package org.eclipse.cargotracker.application.internal;
 import java.util.Date;
 import java.util.logging.Logger;
 
-import javax.ejb.Stateless;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 
 import org.eclipse.cargotracker.application.ApplicationEvents;
@@ -15,9 +15,11 @@ import org.eclipse.cargotracker.domain.model.handling.HandlingEventFactory;
 import org.eclipse.cargotracker.domain.model.handling.HandlingEventRepository;
 import org.eclipse.cargotracker.domain.model.location.UnLocode;
 import org.eclipse.cargotracker.domain.model.voyage.VoyageNumber;
+import org.eclipse.cargotracker.infrastructure.CargoTransactional;
 
 // TODO [Jakarta EE 8] Adopt the Date-Time API.
-@Stateless
+@RequestScoped
+@CargoTransactional
 public class DefaultHandlingEventService implements HandlingEventService {
 
 	@Inject

--- a/src/main/java/org/eclipse/cargotracker/application/util/SampleDataGenerator.java
+++ b/src/main/java/org/eclipse/cargotracker/application/util/SampleDataGenerator.java
@@ -4,16 +4,12 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
-
-import javax.annotation.PostConstruct;
-import javax.ejb.Singleton;
-import javax.ejb.Startup;
-import javax.ejb.TransactionAttribute;
-import javax.ejb.TransactionAttributeType;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-
 import org.eclipse.cargotracker.domain.model.cargo.Cargo;
 import org.eclipse.cargotracker.domain.model.cargo.Itinerary;
 import org.eclipse.cargotracker.domain.model.cargo.Leg;
@@ -26,13 +22,14 @@ import org.eclipse.cargotracker.domain.model.handling.HandlingEventRepository;
 import org.eclipse.cargotracker.domain.model.handling.HandlingHistory;
 import org.eclipse.cargotracker.domain.model.location.SampleLocations;
 import org.eclipse.cargotracker.domain.model.voyage.SampleVoyages;
+import org.eclipse.cargotracker.infrastructure.CargoTransactional;
 import org.joda.time.LocalDate;
 
 /**
  * Loads sample data for demo.
  */
-@Singleton
-@Startup
+@ApplicationScoped
+@CargoTransactional
 public class SampleDataGenerator {
 
 	@Inject
@@ -45,9 +42,7 @@ public class SampleDataGenerator {
 	@Inject
 	private HandlingEventRepository handlingEventRepository;
 
-	@PostConstruct
-	@TransactionAttribute(TransactionAttributeType.REQUIRED)
-	public void loadSampleData() {
+	public void loadSampleData(@Observes @Initialized(ApplicationScoped.class) Object init) {
 		logger.info("Loading sample data.");
 		unLoadAll(); // Fail-safe in case of application restart that does not trigger a JPA schema
 						// drop.

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/CargoTransactional.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/CargoTransactional.java
@@ -1,0 +1,20 @@
+package org.eclipse.cargotracker.infrastructure;
+
+import static java.lang.annotation.ElementType.TYPE;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.Target;
+import javax.enterprise.inject.Stereotype;
+import javax.transaction.Transactional;
+import org.eclipse.cargotracker.domain.model.handling.CannotCreateHandlingEventException;
+
+/**
+ *
+ * @author guillermo
+ */
+@Transactional(rollbackOn = CannotCreateHandlingEventException.class)
+@Stereotype
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface CargoTransactional {
+}

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/routing/ExternalRoutingService.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/routing/ExternalRoutingService.java
@@ -7,7 +7,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
-import javax.ejb.Stateless;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -24,6 +24,7 @@ import org.eclipse.cargotracker.domain.model.location.UnLocode;
 import org.eclipse.cargotracker.domain.model.voyage.VoyageNumber;
 import org.eclipse.cargotracker.domain.model.voyage.VoyageRepository;
 import org.eclipse.cargotracker.domain.service.RoutingService;
+import org.eclipse.cargotracker.infrastructure.CargoTransactional;
 import org.eclipse.pathfinder.api.TransitEdge;
 import org.eclipse.pathfinder.api.TransitPath;
 import org.glassfish.jersey.moxy.json.MoxyJsonFeature;
@@ -33,7 +34,8 @@ import org.glassfish.jersey.moxy.json.MoxyJsonFeature;
  * layer between our domain model and the API put forward by the routing team,
  * which operates in a different context from us.
  */
-@Stateless
+@RequestScoped
+@CargoTransactional
 public class ExternalRoutingService implements RoutingService {
 
 	@Inject

--- a/src/main/java/org/eclipse/cargotracker/interfaces/booking/rest/CargoMonitoringService.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/booking/rest/CargoMonitoringService.java
@@ -2,7 +2,7 @@ package org.eclipse.cargotracker.interfaces.booking.rest;
 
 import java.util.List;
 
-import javax.ejb.Stateless;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -15,7 +15,7 @@ import javax.ws.rs.core.MediaType;
 import org.eclipse.cargotracker.domain.model.cargo.Cargo;
 import org.eclipse.cargotracker.domain.model.cargo.CargoRepository;
 
-@Stateless
+@RequestScoped
 @Path("/cargo")
 public class CargoMonitoringService {
 

--- a/src/main/java/org/eclipse/cargotracker/interfaces/booking/socket/RealtimeCargoTrackingService.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/booking/socket/RealtimeCargoTrackingService.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.ejb.Singleton;
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.json.Json;
@@ -24,7 +24,7 @@ import org.eclipse.cargotracker.infrastructure.events.cdi.CargoInspected;
 /**
  * WebSocket service for tracking all cargoes in real time.
  */
-@Singleton
+@ApplicationScoped
 @ServerEndpoint("/tracking")
 public class RealtimeCargoTrackingService {
 

--- a/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/EventItemWriter.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/EventItemWriter.java
@@ -6,15 +6,14 @@ import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.List;
-
 import javax.batch.api.chunk.AbstractItemWriter;
 import javax.batch.runtime.context.JobContext;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.transaction.Transactional;
-
 import org.eclipse.cargotracker.application.ApplicationEvents;
+import org.eclipse.cargotracker.domain.model.handling.CannotCreateHandlingEventException;
 import org.eclipse.cargotracker.interfaces.handling.HandlingEventRegistrationAttempt;
 
 @Dependent
@@ -38,7 +37,7 @@ public class EventItemWriter extends AbstractItemWriter {
 	}
 
 	@Override
-	@Transactional
+	@Transactional(rollbackOn = CannotCreateHandlingEventException.class)
 	public void writeItems(List<Object> items) throws Exception {
 		try (PrintWriter archive = new PrintWriter(
 				new BufferedWriter(

--- a/src/main/java/org/eclipse/cargotracker/interfaces/handling/rest/HandlingReportService.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/handling/rest/HandlingReportService.java
@@ -4,7 +4,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import javax.ejb.Stateless;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -26,7 +26,7 @@ import org.eclipse.cargotracker.interfaces.handling.HandlingEventRegistrationAtt
  * asynchronous message with the information to the handling event registration
  * system for proper registration.
  */
-@Stateless
+@RequestScoped
 @Path("/handling")
 public class HandlingReportService {
 

--- a/src/main/java/org/eclipse/pathfinder/api/GraphTraversalService.java
+++ b/src/main/java/org/eclipse/pathfinder/api/GraphTraversalService.java
@@ -6,7 +6,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 
-import javax.ejb.Stateless;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -17,7 +17,7 @@ import javax.ws.rs.QueryParam;
 
 import org.eclipse.pathfinder.internal.GraphDao;
 
-@Stateless
+@RequestScoped
 @Path("/graph-traversal")
 public class GraphTraversalService {
 

--- a/src/test/java/org/eclipse/cargotracker/application/BookingServiceTestDataGenerator.java
+++ b/src/test/java/org/eclipse/cargotracker/application/BookingServiceTestDataGenerator.java
@@ -2,12 +2,9 @@ package org.eclipse.cargotracker.application;
 
 import java.util.List;
 import java.util.logging.Logger;
-
-import javax.annotation.PostConstruct;
-import javax.ejb.Singleton;
-import javax.ejb.Startup;
-import javax.ejb.TransactionAttribute;
-import javax.ejb.TransactionAttributeType;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -15,12 +12,13 @@ import javax.persistence.PersistenceContext;
 import org.eclipse.cargotracker.domain.model.cargo.Cargo;
 import org.eclipse.cargotracker.domain.model.location.SampleLocations;
 import org.eclipse.cargotracker.domain.model.voyage.SampleVoyages;
+import org.eclipse.cargotracker.infrastructure.CargoTransactional;
 
 /**
  * Loads sample data for demo.
  */
-@Singleton
-@Startup
+@ApplicationScoped
+@CargoTransactional
 public class BookingServiceTestDataGenerator {
 
 	@Inject
@@ -28,9 +26,7 @@ public class BookingServiceTestDataGenerator {
 	@PersistenceContext
 	private EntityManager entityManager;
 
-	@PostConstruct
-	@TransactionAttribute(TransactionAttributeType.REQUIRED)
-	public void loadSampleData() {
+	public void loadSampleData(@Observes @Initialized(ApplicationScoped.class) Object init) {
 		logger.info("Loading sample data.");
 		unLoadAll(); // Fail-safe in case of application restart that does not
 		// trigger a JPA schema drop.


### PR DESCRIPTION
There's a new `@CargoTransactional` stereotype to handle the rollback of `CannotCreateHandlingEventException` checked exception. Another option is to create a CDI extension that modifies all `@Transactional` uses.

I don't think it's correctly placed on the infrastructure layer as it depends on a domain layer class. Thoughts?