### PR TITLE
Add .DS_Store file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin/
 *.log
 *.log-*
 data
+.DS_Store


### PR DESCRIPTION
I want to get rid of the following annoying message that appears when I run ”git status” command.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.DS_Store
	src/.DS_Store
	src/main/.DS_Store
	src/main/java/.DS_Store
	src/main/java/org/.DS_Store
	src/main/java/org/eclipse/.DS_Store
	src/main/java/org/eclipse/cargotracker/.DS_Store
	src/main/java/org/eclipse/cargotracker/interfaces/.DS_Store
	src/main/java/org/eclipse/cargotracker/interfaces/booking/.DS_Store
	src/main/webapp/.DS_Store
	src/main/webapp/admin/.DS_Store
```