### PR TITLE
Moved broadcaster creation from RealTimeCargoTrackingService init() method to tracking() method, added null checks

### DIFF
--- a/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
@@ -34,7 +34,7 @@ public class RealtimeCargoTrackingService {
 
   @PostConstruct
   public void init() {
-    logger.log(Level.FINEST, "init method invoked");
+    logger.log(Level.FINEST, "@PostConstruct init method invoked.");
   }
 
   @GET

--- a/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
@@ -29,19 +29,23 @@ public class RealtimeCargoTrackingService {
   @Inject private CargoRepository cargoRepository;
 
   @Context private Sse sse;
+
   private SseBroadcaster broadcaster;
 
   @PostConstruct
   public void init() {
-    broadcaster = sse.newBroadcaster();
-    logger.log(Level.FINEST, "SSE broadcaster created.");
+    logger.log(Level.FINEST, "init method invoked");
   }
 
   @GET
   @Produces(MediaType.SERVER_SENT_EVENTS)
-  public void tracking(@Context SseEventSink eventSink) {
+  public void tracking(@Context SseEventSink eventSink, @Context Sse sse) {
+    synchronized (RealtimeCargoTrackingService.class) {
+      if (broadcaster == null) {
+        broadcaster = sse.newBroadcaster();
+      }
+    }
     cargoRepository.findAll().stream().map(this::cargoToSseEvent).forEach(eventSink::send);
-
     broadcaster.register(eventSink);
     logger.log(Level.FINEST, "SSE event sink registered.");
   }
@@ -53,8 +57,10 @@ public class RealtimeCargoTrackingService {
   }
 
   public void onCargoUpdated(@ObservesAsync @CargoUpdated Cargo cargo) {
-    logger.log(Level.FINEST, "SSE event broadcast for cargo: {0}", cargo);
-    broadcaster.broadcast(cargoToSseEvent(cargo));
+    if (broadcaster != null && (sse.newEventBuilder() != null)) {
+      logger.log(Level.FINEST, "SSE event broadcast for cargo: {0}", cargo);
+      broadcaster.broadcast(cargoToSseEvent(cargo));
+    }
   }
 
   private OutboundSseEvent cargoToSseEvent(Cargo cargo) {


### PR DESCRIPTION
Open Liberty with JAXRS 2.x performs context injection after the PostConstruct method is executed while Payara does JAXRS context injection before executing the PostConstruct method. Moving the SSE broadcaster creation from the PostConstruct init() method to the tracking() method in RealTimeCargoTrackingService should allow OL to properly inject the SSE context while preserving application functionality, as the broadcaster should not be needed until events are ready to be received. Checks for the broadcaster and SSE eventBuilder being assigned to non-null values were also added to the onCargoUpdated method prior to running the cargoToSseEvent method. 