### PR TITLE
Moved SSE broadcaster creation from init to tracking method in RealTimeCargoTrackingService, added null checks in onCargoUpdated method

### DIFF
--- a/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
@@ -29,19 +29,24 @@ public class RealtimeCargoTrackingService {
   @Inject private CargoRepository cargoRepository;
 
   @Context private Sse sse;
+
   private SseBroadcaster broadcaster;
 
   @PostConstruct
   public void init() {
-    broadcaster = sse.newBroadcaster();
-    logger.log(Level.FINEST, "SSE broadcaster created.");
+    logger.log(Level.FINEST, "@PostConstruct init() method invoked.");
   }
 
   @GET
   @Produces(MediaType.SERVER_SENT_EVENTS)
-  public void tracking(@Context SseEventSink eventSink) {
+  public void tracking(@Context SseEventSink eventSink, @Context Sse sse) {
+    synchronized (RealtimeCargoTrackingService.class) {
+      if (broadcaster == null) {
+        broadcaster = sse.newBroadcaster();
+        logger.log(Level.FINEST, "SSE broadcaster created.");
+      }
+    }
     cargoRepository.findAll().stream().map(this::cargoToSseEvent).forEach(eventSink::send);
-
     broadcaster.register(eventSink);
     logger.log(Level.FINEST, "SSE event sink registered.");
   }
@@ -53,8 +58,10 @@ public class RealtimeCargoTrackingService {
   }
 
   public void onCargoUpdated(@ObservesAsync @CargoUpdated Cargo cargo) {
-    logger.log(Level.FINEST, "SSE event broadcast for cargo: {0}", cargo);
-    broadcaster.broadcast(cargoToSseEvent(cargo));
+    if (broadcaster != null && (sse.newEventBuilder() != null)) {
+      logger.log(Level.FINEST, "SSE event broadcast for cargo: {0}", cargo);
+      broadcaster.broadcast(cargoToSseEvent(cargo));
+    }
   }
 
   private OutboundSseEvent cargoToSseEvent(Cargo cargo) {

--- a/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/UploadDirectoryScanner.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/UploadDirectoryScanner.java
@@ -1,6 +1,5 @@
 package org.eclipse.cargotracker.interfaces.handling.file;
 
-import javax.annotation.security.RunAs;
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchRuntime;
 import javax.ejb.Schedule;
@@ -15,7 +14,6 @@ import javax.ejb.TransactionManagementType;
  * <p>Files that fail to parse are moved into a separate directory, successful files are deleted.
  */
 @Stateless
-@RunAs("batchAdmin")
 @TransactionManagement(TransactionManagementType.BEAN) // Batch steps manage their own transactions.
 public class UploadDirectoryScanner {
 

--- a/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/UploadDirectoryScanner.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/UploadDirectoryScanner.java
@@ -1,5 +1,6 @@
 package org.eclipse.cargotracker.interfaces.handling.file;
 
+import javax.annotation.security.RunAs;
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchRuntime;
 import javax.ejb.Schedule;
@@ -14,6 +15,7 @@ import javax.ejb.TransactionManagementType;
  * <p>Files that fail to parse are moved into a separate directory, successful files are deleted.
  */
 @Stateless
+@RunAs("batchAdmin")
 @TransactionManagement(TransactionManagementType.BEAN) // Batch steps manage their own transactions.
 public class UploadDirectoryScanner {
 


### PR DESCRIPTION
Open Liberty with JAXRS 2.x performs context injection after the PostConstruct method is executed while Payara does JAXRS context injection before executing the PostConstruct method. Moving the SSE broadcaster creation from the PostConstruct init() method to the tracking() method in RealTimeCargoTrackingService should allow OL to properly inject the SSE context while preserving application functionality, as the broadcaster should not be needed until events are ready to be received. Checks for the broadcaster and SSE eventBuilder being assigned to non-null values were also added to the onCargoUpdated method prior to running the cargoToSseEvent method, which should not affect functionality. 