### PR TITLE
Moved SSE broadcaster creation from init method to tracking method in RealTimeCargoTrackingService

### DIFF
--- a/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
@@ -2,7 +2,6 @@ package org.eclipse.cargotracker.interfaces.booking.sse;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.ejb.Singleton;
 import javax.enterprise.event.ObservesAsync;
@@ -32,11 +31,6 @@ public class RealtimeCargoTrackingService {
 
   private SseBroadcaster broadcaster;
 
-  @PostConstruct
-  public void init() {
-    logger.log(Level.FINEST, "init method invoked");
-  }
-
   @GET
   @Produces(MediaType.SERVER_SENT_EVENTS)
   public void tracking(@Context SseEventSink eventSink, @Context Sse sse) {
@@ -57,14 +51,13 @@ public class RealtimeCargoTrackingService {
   }
 
   public void onCargoUpdated(@ObservesAsync @CargoUpdated Cargo cargo) {
-    if (broadcaster != null && (sse.newEventBuilder() != null)) {
+    if (sse.newEventBuilder() != null) {
       logger.log(Level.FINEST, "SSE event broadcast for cargo: {0}", cargo);
       broadcaster.broadcast(cargoToSseEvent(cargo));
     }
   }
 
   private OutboundSseEvent cargoToSseEvent(Cargo cargo) {
-    System.out.println("cargoToSseEvent sse = " + sse);
     return sse.newEventBuilder()
         .mediaType(MediaType.APPLICATION_JSON_TYPE)
         .data(new RealtimeCargoTrackingViewAdapter(cargo))

--- a/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/UploadDirectoryScanner.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/UploadDirectoryScanner.java
@@ -1,6 +1,5 @@
 package org.eclipse.cargotracker.interfaces.handling.file;
 
-import javax.annotation.security.RunAs;
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchRuntime;
 import javax.ejb.Schedule;
@@ -15,7 +14,6 @@ import javax.ejb.TransactionManagementType;
  * <p>Files that fail to parse are moved into a separate directory, successful files are deleted.
  */
 @Stateless
-@RunAs("batchAdmin")
 @TransactionManagement(TransactionManagementType.BEAN) // Batch steps manage their own transactions.
 public class UploadDirectoryScanner {
 

--- a/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/UploadDirectoryScanner.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/handling/file/UploadDirectoryScanner.java
@@ -1,5 +1,6 @@
 package org.eclipse.cargotracker.interfaces.handling.file;
 
+import javax.annotation.security.RunAs;
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchRuntime;
 import javax.ejb.Schedule;
@@ -14,6 +15,7 @@ import javax.ejb.TransactionManagementType;
  * <p>Files that fail to parse are moved into a separate directory, successful files are deleted.
  */
 @Stateless
+@RunAs("batchAdmin")
 @TransactionManagement(TransactionManagementType.BEAN) // Batch steps manage their own transactions.
 public class UploadDirectoryScanner {
 


### PR DESCRIPTION
Open Liberty with JAXRS 2.x doesn't do SSE context injection until after the PostConstruct method is executed, which is the init() method in this case. Payara injects the SSE context before the method is executed, so this fix moves the SSE broadcaster creation from the PostConstruct init() method to the tracking() method in the RealTimeCargoTrackingService class. The broadcaster should not be needed until there are events that are ready to be received, so the change from creating the broadcaster during initialization should preserve functionality on both OL and Payara. Null checks for the broadcaster and sseEventBuilder were added in the onCargoUpdated method. 
