### PR TITLE
Added DB user/password variables to datasource, Payara confirmed working

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -73,6 +73,8 @@
 		<name>java:app/jdbc/CargoTrackerDatabase</name>
 		<class-name>${db.driverClass}</class-name>
 		<url>${db.jdbcUrl}</url>
+		<user>${db.user}</user>
+		<password>${db.password}</password>
 		<max-pool-size>32</max-pool-size>
 		<min-pool-size>2</min-pool-size>
 	</data-source>


### PR DESCRIPTION
Added the db.user and db.password environment variables to the datasource. They're defined in the bootstrap.properties file for Open Liberty to allow usage with a Postgres Docker container, but they have no effect on the application when running the original Payara implementation without bootstrap.properties. 