### PR TITLE
Tracking webpage fix due to <body> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To set up the project with Open Liberty and Maven:
 
 * Ensure you are running Java SE 8, Java SE 11, or Java SE 17 (IBM Semeru recommended with Open Liberty: https://developer.ibm.com/languages/java/semeru-runtimes/downloads/ -> select from the version dropdown menu.
 * Make sure JAVA_HOME is set.
-* Navigate to the cargotracker directory and develop the application with Liberty Maven Plugin: `mvn -P openliberty liberty:dev`. 
+* Navigate to the cargotracker directory and develop the application with Liberty Maven Plugin: `mvn -P openliberty liberty:dev`.
 
 You can safely ignore the shrinkwrap features warning and the AggregateObjectMapping nested foreign key warning, as these don’t affect the application functionality. 
 
@@ -62,8 +62,7 @@ To set up the project with Open Liberty and Eclipse IDE:
 * The application should start without any further issues beside the cosmetic warnings related to DB setup and message endpoint initialization. 
 * You can view the app at http://localhost:8080/cargo-tracker.
 
-NOTE: On Mac OS, if the ‘mvn’ command is not found by Eclipse, users must start Eclipse through a folder by navigating to their Eclipse version (for example, eclipse/jee-2022-06), right-clicking the Eclipse icon, then selecting “Show Package Contents”.
-Then, navigate to Contents -> MacOS and start Eclipse using the executable file found there. The Maven path should be resolved.
+NOTE: On Mac OS, if the ‘mvn’ command is not found by Eclipse, users must start Eclipse through a folder by navigating to their Eclipse version (for example, eclipse/jee-2022-06), right-clicking the Eclipse icon, then selecting “Show Package Contents”. Then, navigate to Contents -> MacOS and start Eclipse using the executable file found there. The Maven path should be resolved.
 
 ## Exploring the Application
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To set up the project with Open Liberty and Maven:
 
 * Ensure you are running Java SE 8, Java SE 11, or Java SE 17 (IBM Semeru recommended with Open Liberty: https://developer.ibm.com/languages/java/semeru-runtimes/downloads/ -> select from the version dropdown menu.
 * Make sure JAVA_HOME is set.
-* Navigate to the cargotracker directory and develop the application with Liberty Maven Plugin: `mvn -P openliberty liberty:dev`.
+* Navigate to the cargotracker directory and develop the application with Liberty Maven Plugin: `mvn -P openliberty liberty:dev`. 
 
 You can safely ignore the shrinkwrap features warning and the AggregateObjectMapping nested foreign key warning, as these don’t affect the application functionality. 
 
@@ -63,8 +63,7 @@ To set up the project with Open Liberty and Eclipse IDE:
 * You can view the app at http://localhost:8080/cargo-tracker.
 
 NOTE: On Mac OS, if the ‘mvn’ command is not found by Eclipse, users must start Eclipse through a folder by navigating to their Eclipse version (for example, eclipse/jee-2022-06), right-clicking the Eclipse icon, then selecting “Show Package Contents”.
-
-Then, navigate to Contents -> MacOS and start Eclipse using the executable file found there. The Maven path should be resolved. 
+Then, navigate to Contents -> MacOS and start Eclipse using the executable file found there. The Maven path should be resolved.
 
 ## Exploring the Application
 

--- a/src/main/webapp/WEB-INF/templates/common/admin.xhtml
+++ b/src/main/webapp/WEB-INF/templates/common/admin.xhtml
@@ -18,7 +18,8 @@
 		href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" />
 </h:head>
 
-<h:body>
+<body>
+	<f:view>
 	<div class="ui-g full-page">
 		<!-- MENU -->
 		<div class="ui-g-12 ui-md-2 side-panel">
@@ -50,5 +51,6 @@
 			</div>
 		</div>
 	</div>
-</h:body>
+	</f:view>
+</body>
 </html>

--- a/src/main/webapp/WEB-INF/templates/common/public.xhtml
+++ b/src/main/webapp/WEB-INF/templates/common/public.xhtml
@@ -18,7 +18,8 @@
 		href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" />
 </h:head>
 
-<h:body>
+<body>
+	<f:view>
 	<div class="ui-g full-page">
 		<!-- MENU -->
 		<div class="ui-g-12 ui-md-2 side-panel">
@@ -45,5 +46,6 @@
 			</div>
 		</div>
 	</div>
-</h:body>
+	</f:view>
+</body>
 </html>


### PR DESCRIPTION
For Open Liberty/MyFaces, the `<body>` and `<f:view>` tags must be used in the templates (admin.xhtml and public.xhtml) in lieu of the `<h:body>` tag in order for some pages to render properly. 