### PR TITLE
Configure DB in Open Liberty in POM like in other runtimes;  Only activate Payara profile by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
 		<profile>
 			<id>openliberty</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
+				<activeByDefault>false</activeByDefault>
 			</activation>
 			<properties>
 				<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,8 @@
 				<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 				<maven.compiler.source>1.8</maven.compiler.source>
 				<maven.compiler.target>1.8</maven.compiler.target>
+				<db.driverClass>org.hsqldb.jdbc.JDBCDriver</db.driverClass>
+				<db.jdbcUrl>jdbc:hsqldb:file:./cargo-tracker-data/cargo-tracker-database;create=true</db.jdbcUrl>
 			</properties>
 
 			<dependencies>

--- a/src/main/liberty/config/bootstrap.properties
+++ b/src/main/liberty/config/bootstrap.properties
@@ -4,7 +4,3 @@ com.ibm.ws.logging.max.files=3
 default.http.port = 8080
 default.https.port = 8081
 # com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all:com.ibm.ws.jaxrs*=all:com.ibm.websphere.jaxrs*=all:org.apache.cxf.*=all:EJBContainer=all:Injection=all
-db.driverClass = org.hsqldb.jdbc.JDBCDriver
-db.jdbcUrl = jdbc:hsqldb:file:./cargo-tracker-data/cargo-tracker-database;create=true
-db.user=""
-db.password=""


### PR DESCRIPTION
There are two commits here:

The first moves the DB driver class and URL from the Liberty-specific **src/main/liberty/config/bootstrap.properties** into the pom.xml.   I think this is better because it makes clearer that having the payara and openliberty profiles both active creates two conflicting values for these properties (I'm actually not sure how Maven resolves this... maybe in document order?).  Plus doing things in a common way is generally easier to understand.

The second commit flips the activeByDefault value to 'false' for the openliberty profile.   This is a bit more debatable.  This is a Liberty-focused branch... shouldn't Open Liberty be active by default?  Well, then we'd want to have payara NOT active by default, AND, I believe the goal here is to merge this branch into 'master' relatively soon.   Taking for granted the project has decided that payara should be active by default (I haven't really been following) then this would seem to make sense.