### PR TITLE
Fix show.xhtml and route.xhtml in liberty-experimental branch

### DIFF
--- a/src/main/webapp/admin/route.xhtml
+++ b/src/main/webapp/admin/route.xhtml
@@ -5,17 +5,17 @@
 	xmlns:p="http://primefaces.org/ui"
 	xmlns:fn="http://java.sun.com/jsp/jstl/functions">
 <ui:composition template="/WEB-INF/templates/common/admin.xhtml">
+	<f:metadata>
+		<f:viewParam name="trackingId" value="#{cargoDetails.trackingId}" />
+		<f:event type="preRenderView" listener="#{cargoDetails.load}" />
+		<f:viewParam name="trackingId"
+			value="#{itinerarySelection.trackingId}" />
+		<f:event type="preRenderView" listener="#{itinerarySelection.load}" />
+	</f:metadata>
 	<ui:define name="title">Route Cargo #{cargoDetails.trackingId}</ui:define>
 	<ui:define name="content">
-		<f:metadata>
-			<f:viewParam name="trackingId" value="#{cargoDetails.trackingId}" />
-			<f:event type="preRenderView" listener="#{cargoDetails.load}" />
-			<f:viewParam name="trackingId"
-				value="#{itinerarySelection.trackingId}" />
-			<f:event type="preRenderView" listener="#{itinerarySelection.load}" />
-		</f:metadata>
-		<div class="ui-grid-col-2" id="leftCol"></div>
-		<div class="ui-grid-col-8" id="mainCol">
+			<div class="ui-grid-col-2" id="leftCol"></div>
+			<div class="ui-grid-col-8" id="mainCol">
 			<br />
 			<p:outputLabel
 				value="Set Route for Cargo #{cargoDetails.cargo.trackingId}"

--- a/src/main/webapp/admin/show.xhtml
+++ b/src/main/webapp/admin/show.xhtml
@@ -4,20 +4,20 @@
 	xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
 	xmlns:p="http://primefaces.org/ui">
 <ui:composition template="/WEB-INF/templates/common/admin.xhtml">
+	<f:metadata>
+		<f:viewParam name="trackingId" value="#{cargoDetails.trackingId}" />
+		<f:event type="preRenderView" listener="#{cargoDetails.load()}" />
+	</f:metadata>
 	<ui:define name="title">Cargo Details</ui:define>
 	<ui:define name="content">
-		<div class="ui-grid-col-3" id="leftCol"></div>
-		<div class="ui-grid-col-6" id="mainCol">
-			<f:metadata>
-				<f:viewParam name="trackingId" value="#{cargoDetails.trackingId}" />
-				<f:event type="preRenderView" listener="#{cargoDetails.load()}" />
-			</f:metadata>
+			<div class="ui-grid-col-3" id="leftCol"></div>
+			<div class="ui-grid-col-6" id="mainCol">
 			<br />
 			<p:outputLabel
 				value="Routing Details for Cargo #{cargoDetails.cargo.trackingId}"
 				style="font-size: 2em; font-weight: bold" />
 			<p:separator />
-			<h:panelGrid columns="3" styleClass="registrationPanelGrid"
+			<h:panelGrid columns="2" styleClass="registrationPanelGrid"
 				cellpadding="5">
 
 				<p:outputLabel value="Origin:"
@@ -27,7 +27,6 @@
 					<p:outputLabel value="&#160;&#160;#{cargoDetails.cargo.originCode}"
 						style="color: #999999;font-size:.9em;" />
 				</h:panelGroup>
-				<p:outputLabel />
 
 				<p:outputLabel value="Destination:"
 					style="color: #5392c3;font-weight: bold;" />
@@ -37,7 +36,7 @@
 						value="&#160;&#160;#{cargoDetails.cargo.finalDestinationCode}"
 						style="color: #999999;font-size:.9em;" />
 				</h:panelGroup>
-				<p:outputLabel />
+
 				<p:outputLabel value="Arrival deadline:"
 					style="color: #5392c3;font-weight: bold;" />
 				<h:panelGroup>


### PR DESCRIPTION
Go “Administration Interface” > "Routed Cargo" > "ABC123", then got error:

```
/admin/show.xhtml at line 11 and column 16 <f:metadata> Parent UIComponent j_id_a should be instance of UIViewRoot

viewId=/admin/show.xhtml
location=/Users/gkwan/tasks/CNAI/guides/otherrepos/CargoTracker/liberty-experimental/cargotracker/target/cargo-tracker/admin/show.xhtml
phaseId=RENDER_RESPONSE(6)

Caused by:
javax.faces.view.facelets.TagException - /admin/show.xhtml at line 11 and column 16 <f:metadata> Parent UIComponent j_id_a should be instance of UIViewRoot
at org.apache.myfaces.view.facelets.tag.jsf.core.ViewMetadataHandler.apply(ViewMetadataHandler.java:60)
```