### PR TITLE
Fixes #259

### DIFF
--- a/css/bootstrap.min.css
+++ b/css/bootstrap.min.css
@@ -1185,7 +1185,8 @@ figure {
 }
 
 img {
-   vertical-align: middle
+   vertical-align: middle;
+   width: 100%;
 }
 
 .img-responsive,

--- a/css/cargo.css
+++ b/css/cargo.css
@@ -10,6 +10,16 @@ html {
   height: 100%;
 }
 
+.add-padd {
+  padding-top: 412px;
+  transition: 0.2s linear; 
+}
+
+.del-padd {
+  padding-top: 72px;
+  transition: 0.2s linear; 
+}
+
 body,
 h1,
 h2,

--- a/css/cargo.css
+++ b/css/cargo.css
@@ -9,15 +9,16 @@ html {
   width: 100%;
   height: 100%;
 }
-
-.add-padd {
-  padding-top: 412px;
-  transition: 0.2s linear; 
-}
-
-.del-padd {
-  padding-top: 72px;
-  transition: 0.2s linear; 
+@media(max-width:767px) {
+  .add-padd {
+    padding-top: 412px;
+    transition: 0.2s linear; 
+  }
+  
+  .del-padd {
+    padding-top: 72px;
+    transition: 0.2s linear; 
+  }
 }
 
 body,

--- a/index.html
+++ b/index.html
@@ -637,6 +637,16 @@
 									.addClass("active");
 						}
 					});
+			var button = document.getElementsByClassName("navbar-toggle")[0];
+			button.onclick = function() {
+				var clsName = document.getElementsByTagName("body")[0].className;
+				console.log(clsName);
+				if (clsName === "add-padd") {
+					document.getElementsByTagName("body")[0].className = "del-padd";
+				} else {
+					document.getElementsByTagName("body")[0].className = "add-padd";
+				}
+			}
 		</script>
   <!-- Bootstrap Core JavaScript -->
   <script src="js/bootstrap.min.js"></script>


### PR DESCRIPTION
Fixes #259  ,

1) The navigation bar does not cover/hide content when the collapsible button is clicked on a resized view port, i.e the content
    below will pushed down and will be still visible.

2) The page is responsive and now does not leave empty margin spaces and consumes full view port space.

For testing purposes, link to the demo gh-pages site: https://yashtef.github.io/cargotracker/

