### PR TITLE
Change Deadline Bug Fix

### DIFF
--- a/src/main/java/org/eclipse/cargotracker/interfaces/booking/web/ChangeArrivalDeadlineDialog.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/booking/web/ChangeArrivalDeadlineDialog.java
@@ -21,8 +21,8 @@ public class ChangeArrivalDeadlineDialog implements Serializable {
     options.put("modal", true);
     options.put("draggable", true);
     options.put("resizable", false);
-    options.put("contentWidth", 410);
-    options.put("contentHeight", 280);
+    options.put("contentWidth", 500);
+    options.put("contentHeight", 500);
 
     Map<String, List<String>> params = new HashMap<>();
     List<String> values = new ArrayList<>();

--- a/src/main/webapp/admin/dialogs/change_arrival_deadline.xhtml
+++ b/src/main/webapp/admin/dialogs/change_arrival_deadline.xhtml
@@ -12,7 +12,7 @@
 
   <div class="ui-g full-page">
     <h:form>
-      <h:panelGrid columns="2" cellpadding="15">
+      <h:panelGrid columns="2" cellpadding="30">
         <p:outputLabel value="Origin:" />
         <p:outputLabel value="#{changeArrivalDeadline.cargo.originName}" />
 
@@ -21,7 +21,7 @@
           value="#{changeArrivalDeadline.cargo.finalDestinationName}" />
 
         <p:outputLabel value="Deadline: " />
-        <p:datePicker value="#{changeArrivalDeadline.arrivalDeadline}" />
+        <p:datePicker value="#{changeArrivalDeadline.arrivalDeadline}"/>
 
         <p:commandButton value="Cancel"
           action="#{changeArrivalDeadlineDialog.cancel()}" />


### PR DESCRIPTION
Fixes #274 

The problem here was that the header of the calendar widget got covered by the title of the change deadline dialog.

This is how the calendar dialog box is getting rendered now:

![Screenshot from 2023-08-21 00-06-37](https://github.com/eclipse-ee4j/cargotracker/assets/54201446/740e3c19-be6a-48d6-a27d-bbee17f944e0)
