### PR TITLE
chore: clear float for hr tags and add left-right padding to p elements  in smaller screen widths

### DIFF
--- a/css/cargo.css
+++ b/css/cargo.css
@@ -142,7 +142,7 @@ h6 {
 }
 
 .content-section-a {
-  padding: 50px 0;
+  padding: 50px 10px;
   background-color: #f8f8f8;
 }
 
@@ -245,4 +245,12 @@ p.copyright {
 
 .logo-jee {
   width: 58%;
+}
+@media only screen and (max-width: 767px) {
+   .section-heading-spacer {
+	float: inherit;
+  }
+  p.lead {
+	padding: 0 10px;
+  }
 }


### PR DESCRIPTION
For `767px` or smaller screen width:  
This PR
- clears float for `hr` tag
- adds left and right padding to paragraphs

fixes #290 
## Before:
<img src="https://github.com/eclipse-ee4j/cargotracker/assets/110674407/bf8ed73c-b1a1-4a6b-9f84-1e59bf683486" width="250px" height="500px"/>


## After: 
<img src="https://github.com/eclipse-ee4j/cargotracker/assets/110674407/42d2ab75-3e72-4149-a4b1-6907b6991904" width="250px" height="446px"/>
