### PR TITLE
harden: github actions step uses a mutable tag or branc... in...

### DIFF
--- a/nightly.yml
+++ b/nightly.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v3.5.3
               
       - name: Delete Cargo Tracker Deployment
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@9e4b9db4d1b85670b38494b4c8db9d8f4d7b9a49 # master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
@@ -20,7 +20,7 @@ jobs:
         continue-on-error: true    
         
       - name: Delete PostgreSQL Deployment
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@9e4b9db4d1b85670b38494b4c8db9d8f4d7b9a49 # master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
@@ -28,7 +28,7 @@ jobs:
         continue-on-error: true
 
       - name: Create PostgreSQL Config Map
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@9e4b9db4d1b85670b38494b4c8db9d8f4d7b9a49 # master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
@@ -36,20 +36,20 @@ jobs:
         continue-on-error: true
         
       - name: Create PostgreSQL Deployment
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@9e4b9db4d1b85670b38494b4c8db9d8f4d7b9a49 # master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
           args: create -f postgres.yml
       
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@cd89f46ac9d01407894a1f2642c674d27e8cf9c4 # v3.13.0
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -59,21 +59,21 @@ jobs:
         run: ./mvnw clean package -Pcloud -DpostgreSqlJdbcUrl="jdbc:postgresql://postgres:5432/postgres" -DpostgreSqlUsername="${{ secrets.POSTGRES_USER }}" -DpostgreSqlPassword="${{ secrets.POSTGRES_PASSWORD }}" --file pom.xml
         
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: ghcr.io
           username: eclipse-ee4j
           password: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v3.2.0
         with:
           context: .
           push: true
           tags: ghcr.io/eclipse-ee4j/cargo-tracker:latest,ghcr.io/eclipse-ee4j/cargo-tracker:v3.1-SNAPSHOT
                       
       - name: Create Cargo Tracker Deployment
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@9e4b9db4d1b85670b38494b4c8db9d8f4d7b9a49 # master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:


### PR DESCRIPTION
## Summary
Harden input handling in `nightly.yml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag` |
| **File** | `nightly.yml:12` |
| **Assessment** | Defensive hardening |

**Description**: GitHub Actions step uses a mutable tag or branch reference. Tags and branch names can be silently repointed by the action owner, enabling supply-chain attacks — as seen in the trivy-action and kics-github-action compromises. Pin the reference to a full 40-character commit SHA instead, e.g. `uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608`.

## Threat Model Context

This is a Java service - vulnerabilities in servlets/controllers are remotely exploitable.

## Changes
- `nightly.yml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
